### PR TITLE
DOC: ignore ansys.stk.core.internal

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -87,3 +87,4 @@ autoapi_options = [
 autoapi_template_dir = "_autoapi_templates"
 exclude_patterns = ["_autoapi_templates/index.rst"]
 autoapi_python_use_implicit_namespaces = True
+autoapi_ignore = ["*internal*"]


### PR DESCRIPTION
As per private discussions, we agreed on not rendering within the documentation all the modules included in the sub-package `internal`.

Note that some references still point to the internal package, raising some warnings when documentation gets built.