### PR TITLE
MAINT: get version value dynamically

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "ansys-stk-core"
-version = "0.1.dev0"
+dynamic = ["version"]
 description = "A Python API for STK"
 readme = "README.rst"
 requires-python = ">=3.6"
@@ -23,7 +23,6 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "importlib-metadata >=4.0",
 ]
 
 [project.optional-dependencies]

--- a/src/ansys/stk/core/__init__.py
+++ b/src/ansys/stk/core/__init__.py
@@ -4,9 +4,5 @@ PySTK.
 A Python API for Systems Tool Kit (STK).
 """
 
-try:
-    import importlib.metadata as importlib_metadata
-except ModuleNotFoundError:
-    import importlib_metadata
 
-__version__ = importlib_metadata.version(__name__.replace(".", "-"))
+__version__ = "0.1.dev0"


### PR DESCRIPTION
Fix #57 by reading the version value from the `__init__.py` file. This allows to no longer depend on the `importlib-metadata` library.