### PR TITLE
MAINT: downgrade Sphinx version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ tests = [
 doc = [
     "ansys-sphinx-theme==0.8.1",
     "numpydoc==1.5.0",
-    "sphinx==6.1.3",
+    "sphinx==5.3.0",
     "sphinx-copybutton==0.5.1",
     "enum-tools[sphinx]==0.9.0.post1",
 ]


### PR DESCRIPTION
Allows to merge #77. Our Ansys theme does not support `Sphinx>=6.0` yet.