### PR TITLE
DOC: update intersphinx to point to stable Python 3

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -54,7 +54,7 @@ extensions = [
 
 # Intersphinx mapping
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/dev", None),
+    "python": ("https://docs.python.org/3", None),
 }
 
 # numpydoc configuration


### PR DESCRIPTION
As per some internal discussion, this pull-request points the ``intersphinx-mapping`` to the stable Python 3 documentation.