### PR TITLE
Update tox.ini after tox 4.8.0 upgrade

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 description = Default tox environments list
 envlist =
-    style,tests,doc
+    style,tests-{aviator,stk,vgt}-{graphics,nographics}-{cov,nocov}-linux,doc
 skip_missing_interpreters = true
 isolated_build = true
 isolated_build_env = build


### PR DESCRIPTION
Running tests broke with the error below after upgrading to tox 4.8.0 because of https://github.com/tox-dev/tox/pull/3089 which requires the environments to be explicitly specified in the config file. This change explicitly declares the possible environments in the config file.

Run docker exec \
  docker exec \
    --workdir /home/stk/pystk \
    stk-python3.8 /bin/bash -c \
    "export COVERAGE_FILE=aviator && tox -e tests-aviator-graphics-cov-linux"
  shell: /usr/bin/bash -e {0}
  env:
    MAIN_PYTHON_VERSION: 3.10
    LIBRARY_NAME: ansys-stk-core
    LIBRARY_NAMESPACE: ansys.stk.core
    DOCUMENTATION_CNAME: stk.docs.pyansys.com
    STK_DOCKER_IMAGE: ansys/stk:latest-centos7
    PYSTK_DIR: /home/stk/pystk
    LICENSE_SERVER_PORT: 1055
    STK_PYTHON_IMAGE: ansys/stk:latest-centos7-python3.8
    STK_CONTAINER: stk-python3.8
ROOT: HandledError| provided environments not found in configuration file: ['tests-aviator-graphics-cov-linux'] Error: Process completed with exit code 254.