### PR TITLE
Re-enable the access constraint tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ commands =
     pytest {env:PYTEST_PYTHON_FILES:tests} {env:PYTEST_EXTRA_ARGS:} \
         {env:PYTEST_TARGET:} {env:PYTEST_EXCLUDE_LINUX:} \
         {env:PYTEST_WITH_GRAPHICS:} {env:PYTEST_EXCLUDE_GRAPHICS:} \
-        {env:PYTEST_EXCLUDE_VO:} --exclude PluginTests --exclude 'AccessConstraints Tests' {posargs:-vv}
+        {env:PYTEST_EXCLUDE_VO:} --exclude PluginTests {posargs:-vv}
 
 [testenv:style]
 description = Checks project code style


### PR DESCRIPTION
We turned off these tests at some point while troubleshooting an [unrelated issue](https://github.com/ansys-internal/pystk/pull/133/commits/a5c23999bca486c379453014002ccad9e86417df) with the container, re-enabling them as they now pass.