### PR TITLE
maint: limit Sphinx version to 6.2.1 to work with enum-tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ doc = [
     "ansys-sphinx-theme==0.10.4",
     "enum-tools[sphinx]==0.10.0",
     "numpydoc==1.5.0",
-    "sphinx==7.2.2",
+    "sphinx==6.2.1",
     "sphinx-design==0.5.0",
     "sphinx-jinja==2.0.2",
     "sphinx-copybutton==0.5.2",


### PR DESCRIPTION
Limits the Sphinx version to ensure compatibility with the `enum-tools` package. See issues in https://github.com/domdfcoding/enum_tools/issues/77