### PR TITLE
maint: migrate codespell config to pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,8 @@ repos:
   rev: v2.2.1
   hooks:
   - id: codespell
-    args: ["--ignore-words", "doc/styles/Vocab/ANSYS/accept.txt"]
+    additional_dependencies:
+      - tomli
 
 - repo: https://github.com/pycqa/pydocstyle
   rev: 6.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ line_length = 80
 default_section = "THIRDPARTY"
 src_paths = ["examples", "doc", "src", "tests"]
 
+[tool.codespell]
+ignore-words = "doc/styles/Vocab/ANSYS/accept.txt"
+
 [tool.coverage.run]
 relative_files = true
 


### PR DESCRIPTION
Fix #76 by migrating the codespell configuration to the `pyproject.toml` file.