### PR TITLE
fix: include inputs under workflow dispatch option

### DIFF
--- a/.github/workflows/ci_cd_night.yml
+++ b/.github/workflows/ci_cd_night.yml
@@ -34,7 +34,7 @@ jobs:
   doc-build:
     name: "Doc build"
     runs-on: ubuntu-latest
-    if: inputs.run-doc == 'true'
+    if: inputs.run-doc
     steps:
       - name: "Building project documentation"
         uses: ansys/actions/doc-build@v4
@@ -47,7 +47,7 @@ jobs:
   tests:
     name: "Tests Python ${{ matrix.python }}"
     runs-on: [self-hosted, pystk]
-    if: inputs.run-tests == 'true'
+    if: inputs.run-tests
     strategy:
       matrix:
         python: ["3.8", "3.9", "3.10"]


### PR DESCRIPTION
Continuation of #190. Fixes the location of the input options to ensure that they are available when performing a workflow dispatch.

It is now rendering as expected, see:

![Screenshot 2023-09-28 at 20-58-05 night · Workflow runs · ansys-internal_pystk](https://github.com/ansys-internal/pystk/assets/28702884/baa97e20-6460-4d15-abc0-85d96146bb97)

Working in https://github.com/ansys-internal/pystk/actions/runs/6343102142