### PR TITLE
doc: ignore Sphinx roles in Vale

### DIFF
--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -26,3 +26,6 @@ Vocab = ANSYS
 
 # Apply the following styles
 BasedOnStyles = Vale, Google
+
+# Inline roles are ignored
+TokenIgnores = (:.*:`.*`)|(<.*>)


### PR DESCRIPTION
This pull-request fixes the failing doc style issue caused by Vale by ignoring any content within role directives. Role directives are directives declared inline, like `:class:`, `:method:`, and similar.