### PR TITLE
Updated tox.ini to support running docker Linux containers locally while developing on Windows

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -78,21 +78,17 @@ commands =
 # Using these during a CI/CD can lead to unexpected issues due to a Docker-In-Docker
 # situation.
 
-[testenv:docker-build-{linux,windows}]
-description = Build all the available Docker images for a desired platform
+[testenv:docker-build]
+description = Build all the available Docker Linux images 
 skip_install = true
-platform = 
-    linux: linux
-    windows: win32
 allowlist_externals =
     docker
     compose
 commands =
-    linux: docker compose --file "{toxinidir}/docker/linux/docker-compose.yml" build
-    windows: docker compose --file "{toxinidir}/docker/windows/docker-compose.yml" build
+    docker compose --file "{toxinidir}/docker/linux/docker-compose.yml" build
 
 [testenv:docker-run-{linux,windows}-{py38,py39,py310}]
-description = Run a Docker container with the desired Python version, STK, and the current PySTK
+description = Run a Linux Docker container with the desired Python version, STK, and the current PySTK
 skip_install = true
 platform = 
     linux: linux
@@ -101,24 +97,23 @@ setenv =
     py38: PYTHON_VERSION = 3.8
     py39: PYTHON_VERSION = 3.9
     py310: PYTHON_VERSION = 3.10
-    linux: PLATFORM_ARGS = --env DISPLAY={env:DISPLAY} --entrypoint /bin/bash
+    linux: PLATFORM_ARGS = --network="host" --env DISPLAY={env:DISPLAY} --entrypoint /bin/bash
     linux: PLATFORM_CMD = /bin/bash -c "cd /home/stk && python -m venv .venv && python -m pip install -e /home/stk/pystk[tests,doc]"
-    windows: PLATFORM_ARGS = #TODO
-    windows: PLATFORM_CMD = #TODO
+    windows: PLATFORM_ARGS = -p 8888:8888 --entrypoint /bin/bash
+    windows: PLATFORM_CMD = /bin/bash -c "cd /home/stk && python -m venv .venv && python -m pip install -e /home/stk/pystk[tests,doc]"
 allowlist_externals =
     docker
 commands =
     # Start a container with the desired configuration
     docker run \
         --detach --interactive --tty \
-        --network="host" \
         --volume "{toxinidir}:/home/stk/pystk" \
         --env ANSYSLMD_LICENSE_FILE={env:ANSYSLMD_LICENSE_FILE} \
         {env:PLATFORM_ARGS} \
         --name stk-python{env:PYTHON_VERSION} \
         ansys/stk:latest-centos7-python{env:PYTHON_VERSION}
 
-    # HACK: a virtual environmnet fixes allows Jupyter Lab to operate as expected.
+    # HACK: a virtual environment fixes allows Jupyter Lab to operate as expected.
     # These issues may be raised because of the custom Python installation 
     # in the Docker images. 
     # TODO: Once gRPC is enabled, this should be revisited since Python will 
@@ -126,38 +121,36 @@ commands =
     docker exec --interactive --tty \
         stk-python{env:PYTHON_VERSION} {env:PLATFORM_CMD}
 
-[testenv:docker-exec-{linux,windows}-{py38,py39,py310}]
-description = Exec a Python script using the desired STK container
+[testenv:docker-exec-{py38,py39,py310}]
+description = Exec a command using the desired STK container
 skip_install = true
 setenv =
     py38: PYTHON_VERSION = 3.8
     py39: PYTHON_VERSION = 3.9
     py310: PYTHON_VERSION = 3.10
-    linux: PLATFORM_CMD = /bin/bash -c 'cd /home/stk && source .venv/bin/activate && python {posargs}'
-    windows: PLATFORM_CMD = #TODO
+    VENV_CMD = /bin/bash -c 'cd /home/stk && source .venv/bin/activate && {posargs}'
 allowlist_externals =
     docker
 commands =
     docker exec --interactive --tty \
-        stk-python{env:PYTHON_VERSION} {env:PLATFORM_CMD}
+        stk-python{env:PYTHON_VERSION} {env:VENV_CMD}
 
-[testenv:docker-exec-{linux,windows}-{py38,py39,py310}-lab]
-description = Exec a Python script using the desired STK container
+[testenv:docker-exec-{py38,py39,py310}-lab]
+description = Run jupyter lab using the desired STK container
 skip_install = true
 setenv =
     py38: PYTHON_VERSION = 3.8
     py39: PYTHON_VERSION = 3.9
     py310: PYTHON_VERSION = 3.10
-    linux: PLATFORM_CMD = /bin/bash -c 'cd /home/stk && source .venv/bin/activate && jupyter lab --ip=0.0.0.0 --port 8888 --no-browser --NotebookApp.token=pystk --notebook-dir=/home/stk/pystk'
-    windows: PLATFORM_CMD = #TODO
+    LAB_CMD = /bin/bash -c 'cd /home/stk && source .venv/bin/activate && jupyter lab --ip=0.0.0.0 --port 8888 --no-browser --NotebookApp.token=pystk --notebook-dir=/home/stk/pystk'
 allowlist_externals =
     docker
 commands =
     docker exec --interactive --tty \
-        stk-python{env:PYTHON_VERSION} {env:PLATFORM_CMD}
+        stk-python{env:PYTHON_VERSION} {env:LAB_CMD}
 
 [testenv:docker-stop-{py38,py39,py310}]
-description = Run a Docker container with the desired Python version, STK, and the current PySTK
+description = Stop the Docker container with the desired Python version, STK, and the current PySTK
 skip_install = true
 setenv =
     py38: PYTHON_VERSION = 3.8


### PR DESCRIPTION
This makes the following commands work on Windows:

```
python -m tox -e docker-build
python -m tox -e docker-run-windows-py310
python -m tox -e docker-exec-py310 -- ls
python -m tox -e docker-exec-py310-lab
python -m tox -e docker-stop-py310
python -m tox -e docker-rm-py310
```