### PR TITLE
fix: do not check for certificate when installing OpenSSL

### DIFF
--- a/docker/linux/stk-engine-pybase/Dockerfile
+++ b/docker/linux/stk-engine-pybase/Dockerfile
@@ -24,7 +24,7 @@ RUN set -e; \
 
 # Install OpenSSL 1.1
 RUN set -e; \
-   wget https://ftp.openssl.org/source/openssl-1.1.1k.tar.gz; \
+   wget --no-check-certificate https://ftp.openssl.org/source/openssl-1.1.1k.tar.gz; \
    tar -xzvf openssl-1.1.1k.tar.gz; \
    cd openssl-1.1.1k; \
    ./config --prefix=/usr --openssldir=/etc/ssl --libdir=lib no-shared zlib-dynamic; \


### PR DESCRIPTION
This pull-request ensures that OpenSSL gets installed by not checking for the certificate. Otherswise, `wget` complains.