### PR TITLE
Tweak dockerfiles to avoid breaking yum

### DIFF
--- a/docker/linux/stk-engine-py310/Dockerfile
+++ b/docker/linux/stk-engine-py310/Dockerfile
@@ -41,14 +41,14 @@ COPY --from=builder /usr/local/bin/python3.10 /usr/local/bin/python3.10
 COPY --from=builder /usr/local/lib/python3.10 /usr/local/lib/python3.10 
 COPY --from=builder /usr/local/bin/pip3.10 /usr/local/bin/pip3.10 
 
-RUN ln -sfn /usr/local/bin/python3.10 /usr/bin/python && \
-    ln -sfn /usr/local/bin/pip3.10 /usr/bin/pip
+RUN ln -sfn /usr/local/bin/python3.10 /usr/local/bin/python && \
+    ln -sfn /usr/local/bin/pip3.10 /usr/local/bin/pip
 
 # Switch back to non-root user
 USER stk
 
 # Update the path to include Python executables
-ENV PATH="${STK_USER_HOME}/.local/bin:${PATH}" \
+ENV PATH="/usr/local/bin:${STK_USER_HOME}/.local/bin:${PATH}" \
     PIP_DEFAULT_TIMEOUT=600 \
     PIP_RETRY=50
 

--- a/docker/linux/stk-engine-py38/Dockerfile
+++ b/docker/linux/stk-engine-py38/Dockerfile
@@ -41,14 +41,14 @@ COPY --from=builder /usr/local/bin/python3.8 /usr/local/bin/python3.8
 COPY --from=builder /usr/local/lib/python3.8 /usr/local/lib/python3.8 
 COPY --from=builder /usr/local/bin/pip3.8 /usr/local/bin/pip3.8 
 
-RUN ln -sfn /usr/local/bin/python3.8 /usr/bin/python && \
-    ln -sfn /usr/local/bin/pip3.8 /usr/bin/pip
+RUN ln -sfn /usr/local/bin/python3.8 /usr/local/bin/python && \
+    ln -sfn /usr/local/bin/pip3.8 /usr/local/bin/pip
 
 # Switch back to non-root user
 USER stk
 
 # Update the path to include Python executables
-ENV PATH="${STK_USER_HOME}/.local/bin:${PATH}" \
+ENV PATH="/usr/local/bin:${STK_USER_HOME}/.local/bin:${PATH}" \
     PIP_DEFAULT_TIMEOUT=600 \
     PIP_RETRY=50
 

--- a/docker/linux/stk-engine-py39/Dockerfile
+++ b/docker/linux/stk-engine-py39/Dockerfile
@@ -41,14 +41,14 @@ COPY --from=builder /usr/local/bin/python3.9 /usr/local/bin/python3.9
 COPY --from=builder /usr/local/lib/python3.9 /usr/local/lib/python3.9 
 COPY --from=builder /usr/local/bin/pip3.9 /usr/local/bin/pip3.9 
 
-RUN ln -sfn /usr/local/bin/python3.9 /usr/bin/python && \
-    ln -sfn /usr/local/bin/pip3.9 /usr/bin/pip
+RUN ln -sfn /usr/local/bin/python3.9 /usr/local/bin/python && \
+    ln -sfn /usr/local/bin/pip3.9 /usr/local/bin/pip
 
 # Switch back to non-root user
 USER stk
 
 # Update the path to include Python executables
-ENV PATH="${STK_USER_HOME}/.local/bin:${PATH}" \
+ENV PATH="/usr/local/bin:${STK_USER_HOME}/.local/bin:${PATH}" \
     PIP_DEFAULT_TIMEOUT=600 \
     PIP_RETRY=50
 


### PR DESCRIPTION
The yum package manager on CentOS 7 requires `/usr/bin/python` to be pointing to Python 2. Made sure that that link did not get altered by adding a symlink for the locally build Python 3 to `/usr/local/bin/python` and by making the `/usr/local/bin` path first in the system PATH environment variable. That way using the `python` command still points to the locally built Python 3 version, but `yum` still finds Python 2 at `/usr/bin/python` (that path is hardcoded at the first line of the yum script).