### PR TITLE
ci: add timeout for doc-build job

### DIFF
--- a/.github/workflows/ci_cd_main.yml
+++ b/.github/workflows/ci_cd_main.yml
@@ -17,6 +17,7 @@ jobs:
   doc-build:
     name: "Doc build excluding 'API' and 'Examples' sections"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
 
       - name: "Build project documentation excluding 'API' and 'Example' sections"

--- a/.github/workflows/ci_cd_night.yml
+++ b/.github/workflows/ci_cd_night.yml
@@ -34,6 +34,7 @@ jobs:
   doc-build:
     name: "Doc build"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: inputs.run-doc || github.event_name == 'schedule'
     steps:
       - name: "Building project documentation"

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -67,6 +67,7 @@ jobs:
     name: "Doc build"
     runs-on: ubuntu-latest
     needs: doc-style
+    timeout-minutes: 30
     steps:
 
       # Render the documentation including or excluding different sections


### PR DESCRIPTION
This pull-request introduces a timeout for the `doc-build` step in the CI/CD workflows. The reason is that from time to time, previous job step gets running forever until the 6h limit is reached. See for instance https://github.com/ansys-internal/pystk/actions/runs/6843917362/job/18607049565