### PR TITLE
ci: fix cron syntax in nightly build action

### DIFF
--- a/.github/workflows/ci_cd_night.yml
+++ b/.github/workflows/ci_cd_night.yml
@@ -21,7 +21,7 @@ on:
     - cron: '0 0 * * 1-5'
     # From Saturday to Sunday (both included) at 00:00 UTC. Used for running the
     # complete list of Python versions.
-    - cron: '0 0 * * 6-7'
+    - cron: '0 0 * * 6,0'
 
 env:
   MAIN_PYTHON_VERSION: '3.10'


### PR DESCRIPTION
Sunday is represented with 0 since it is the first day of the week.