### PR TITLE
Fix documentation build

### DIFF
--- a/doc/source/api/ansys/stk/core/stkengine/index.rst
+++ b/doc/source/api/ansys/stk/core/stkengine/index.rst
@@ -26,7 +26,7 @@ Classes
 
    STKEngine
    STKEngineApplication
-   STKEngineTimerType
+   STK_ENGINE_TIMER_TYPE
 
 Reference
 #########
@@ -42,6 +42,6 @@ Classes
     :members:
     :exclude-members: __init__
 
-.. autoclass:: STKEngineTimerType
+.. autoclass:: STK_ENGINE_TIMER_TYPE
     :members:
     :exclude-members: __init__


### PR DESCRIPTION
Fix the documentation build error below:

```
/home/runner/work/pystk/pystk/doc/source/api/ansys/stk/core/stkengine/index.rst:25: 
WARNING: autosummary: failed to import STKEngineTimerType.
```