### PR TITLE
ci: fix syntaxt for nightly build

### DIFF
--- a/.github/workflows/ci_cd_night.yml
+++ b/.github/workflows/ci_cd_night.yml
@@ -58,10 +58,12 @@ jobs:
       matrix:
         python: ["3.8", "3.9", "3.10"]
         is-weekly-run:
-          - ${{ github.event_name == 'schedule' && github.event.schedule == '0 0 * * 6,0' }}
+          - ${{ github.event_name == 'schedule' && github.event.schedule == '0 0 * * 1-5' }}
         exclude:
           - is-weekly-run: true
-            python: ["3.8", "3.9"]
+            python: "3.8"
+          - is-weekly-run: true
+            python: "3.9"
       fail-fast: false
     steps:
 


### PR DESCRIPTION
Aims to solve for #248. Fixes the checking condition and splits the list of versions into separate keys.

I bet the list of versions needs to be split the value of Python is a string and not a list of strings.