### PR TITLE
fix: groups in dependabot.yml file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,19 +10,21 @@ updates:
       prefix: "maint"
     groups:
       tests:
-        - "pytest*"
-        - "pytz"
-        - "parametrized"
+        patterns:
+          - "pytest*"
+          - "pytz"
+          - "parametrized"
       doc:
-        - "jupyter*"
-        - "jupytext"
-        - "myst*"
-        - "nbsphinx"
-        - "numpy*"
-        - "*sphinx*"
-        - "Pillow"
-        - "simplejpeg"
-        - "sidecar"
+        patterns:
+          - "jupyter*"
+          - "jupytext"
+          - "myst*"
+          - "nbsphinx"
+          - "numpy*"
+          - "*sphinx*"
+          - "Pillow"
+          - "simplejpeg"
+          - "sidecar"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Continuation of #289. Fixes the missing `patterns` key in the `dependabot.yml` file.