### PR TITLE
fix: add nbconvert to doc group in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,7 @@ updates:
           - "myst*"
           - "nbsphinx"
           - "numpy*"
+          - "nbconvert"
           - "*sphinx*"
           - "Pillow"
           - "simplejpeg"


### PR DESCRIPTION
Ensures that pull-requests like #295 are included in #296.