### PR TITLE
fix: example thumbnail

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -160,7 +160,7 @@ else:
         ".py": ["jupytext.reads", {"fmt": ""}],
     }
     nbsphinx_thumbnails = {
-        "examples/stk_engine/hohmann_transfer_using_targeter": "_static/thumbnails/hohmann-transfer-using-targeter.png",
+        "examples/hohmann_transfer_using_targeter": "_static/thumbnails/hohmann-transfer-using-targeter.png",
     }
     nbsphinx_prompt_width = ""
     nbsphinx_prolog = """


### PR DESCRIPTION
Continuation of #304. Ensures that the thumbnail is compliant with the new flat layout in the `examples/` folder generated when building the docs.