### PR TITLE
fix: code linting configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.1.6
+  rev: v0.3.4
   hooks:
+    # Run the linter
     - id: ruff
-      args: [--fix]
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,15 +85,15 @@ select = [
 ]
 ignore = [
 #    "E501",  # Line too long. Ignoring this so "ruff.formatter" manages line length.
-
-    # Ignored intentionally
-    "D203", # 1 blank line required before class docstring - Incompatible with D211: `one-blank-line-before-class`.
-    "D212", # Multi-line docstring summary should start at the first line - Incompatible with D213: `multi-line-summary-second-line`.
-    "D400", # First line should end with a period - This check is redundant, D415 checks this and allows for other punctuation.
+    "D212", # Multi-line docstring summary should start at the first line
 ]
 
+[tool.ruff.lint.pydocstyle]
+# Settings: https://docs.astral.sh/ruff/settings/#lintpydocstyle
+convention = "google"
+
 # [tool.ruff.format]
-# quote-style = "single"
+# quote-style = "double"
 # indent-style = "tab"
 
 # [tool.ruff.isort]


### PR DESCRIPTION
This pull-request ensures that PyDocstyle uses Numpy docstring convention. This change solves some rules conflicts, allowing to remove those from the `ignore` list.