### PR TITLE
fix: libgfortran5 install in Dockerfiles

### DIFF
--- a/docker/linux/ubuntu/stk-engine/Dockerfile
+++ b/docker/linux/ubuntu/stk-engine/Dockerfile
@@ -45,6 +45,7 @@ ENV STK_USER_HOME=/home/stk
 # Setup non-root STK user
 RUN set -e; \
     useradd -ms /bin/bash stk; \
+    apt-get update; \
     apt-get install --no-install-recommends -y libgfortran5; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Continuation of #311. This pull-request runs the `apt-get update` command before installing the `libgfortran5` version. Otherwise, this version of the library is not available and Docker raises the error:

> Unable to locate package libgfortran5