### PR TITLE
fix: localtime and timezone in ubuntu images

### DIFF
--- a/docker/linux/ubuntu/stk-engine-py310/Dockerfile
+++ b/docker/linux/ubuntu/stk-engine-py310/Dockerfile
@@ -47,6 +47,12 @@ COPY docker-entrypoint.sh "${STK_USER_HOME}/bin/docker-entrypoint.sh"
 RUN chmod +x "${STK_USER_HOME}/bin/docker-entrypoint.sh"; \
     dos2unix "${STK_USER_HOME}/bin/docker-entrypoint.sh"
 
+# Fix timezone and localtime. See the following issue with Ubuntu 20.04:
+# Issue: https://bugs.launchpad.net/ubuntu/+source/tzdata/+bug/1899343
+RUN set -e; \
+    ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime; \
+    echo 'Etc/UTC' > /etc/timezone
+
 # Switch back to non-root user
 USER stk
 

--- a/docker/linux/ubuntu/stk-engine-py38/Dockerfile
+++ b/docker/linux/ubuntu/stk-engine-py38/Dockerfile
@@ -47,6 +47,12 @@ COPY docker-entrypoint.sh "${STK_USER_HOME}/bin/docker-entrypoint.sh"
 RUN chmod +x "${STK_USER_HOME}/bin/docker-entrypoint.sh"; \
     dos2unix "${STK_USER_HOME}/bin/docker-entrypoint.sh"
 
+# Fix timezone and localtime. See the following issue with Ubuntu 20.04:
+# Issue: https://bugs.launchpad.net/ubuntu/+source/tzdata/+bug/1899343
+RUN set -e; \
+    ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime; \
+    echo 'Etc/UTC' > /etc/timezone
+
 # Switch back to non-root user
 USER stk
 

--- a/docker/linux/ubuntu/stk-engine-py39/Dockerfile
+++ b/docker/linux/ubuntu/stk-engine-py39/Dockerfile
@@ -47,6 +47,12 @@ COPY docker-entrypoint.sh "${STK_USER_HOME}/bin/docker-entrypoint.sh"
 RUN chmod +x "${STK_USER_HOME}/bin/docker-entrypoint.sh"; \
     dos2unix "${STK_USER_HOME}/bin/docker-entrypoint.sh"
 
+# Fix timezone and localtime. See the following issue with Ubuntu 20.04:
+# Issue: https://bugs.launchpad.net/ubuntu/+source/tzdata/+bug/1899343
+RUN set -e; \
+    ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime; \
+    echo 'Etc/UTC' > /etc/timezone
+
 # Switch back to non-root user
 USER stk
 


### PR DESCRIPTION
Continuation of #311 and #325. Ensures that the `/etc/timezone` file exists and that `/etc/localtime` has the right value.

Despite adding these changes at the level of `stk-engine-pybase/Dockerfile`, they did not have any effect. Values in previous `/etc/` files were still invalid.

Declaring this at `stk-engine-py3X` solved the issue. 

Testing these changes in #326.