### PR TITLE
fix: remove reference to .flake8 file

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -29,7 +29,7 @@
 'code-style':
   - any:
       - changed-files:
-          - any-glob-to-any-file: ['.pre-commit-config.yaml', 'doc/.vale.ini', '.flake8']
+          - any-glob-to-any-file: ['.pre-commit-config.yaml', 'doc/.vale.ini']
 
 'docker':
   - any:


### PR DESCRIPTION
This pull-request removes a reference in the `labeler.yml` file to the no longer present `.flake8` file.