### PR TITLE
ci: use only Python 3.11 during nightly and weekdays CI/CD sessions

### DIFF
--- a/.github/workflows/ci_cd_night.yml
+++ b/.github/workflows/ci_cd_night.yml
@@ -109,6 +109,8 @@ jobs:
         exclude:
           - is-weekly-run: true
             python: "3.9"
+          - is-weekly-run: true
+            python: "3.10"
       fail-fast: false
     steps:
 


### PR DESCRIPTION
This pull-request ensures that the nightly CI/CD runs during weekdays only run using Python 3.11. Stops the issues seen in [this run](https://github.com/ansys-internal/pystk/actions/runs/9688603010).