### PR TITLE
fix: use encoding copying examples in doc build

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -308,7 +308,7 @@ def copy_examples_to_output_dir(app: sphinx.application.Sphinx, exception: Excep
             stringify_func=(lambda x: x.name),
     ):
         destination_file = OUTPUT_EXAMPLES / file.name
-        destination_file.write_text(file.read_text())
+        destination_file.write_text(file.read_text(encoding="utf-8"), encoding="utf-8")
     
 
 def remove_examples_from_source_dir(app: sphinx.application.Sphinx, exception: Exception):


### PR DESCRIPTION
This is to prevent the following error issued from the `copy_examples_to_output_dir` function when building the doc on a Windows machine invoked by `tox -e doc-html`:

```
Traceback (most recent call last):
  File "D:\Dev\github_root\pystk2\.tox\doc-html\lib\site-packages\sphinx\events.py", line 97, in emit
    results.append(listener.handler(self.app, *args))
  File "D:\Dev\github_root\pystk2\doc\source\conf.py", line 311, in copy_examples_to_output_dir
    destination_file.write_text(file.read_text())
  File "d:\Dev\Python310\lib\pathlib.py", line 1135, in read_text
    return f.read()
  File "d:\Dev\Python310\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 3490: character maps to <undefined>
```