### PR TITLE
fix: image link

### DIFF
--- a/doc/source/getting-started/building-stk-images.rst
+++ b/doc/source/getting-started/building-stk-images.rst
@@ -44,7 +44,7 @@ the relation between the different Docker images:
     .. tab-item:: STK images for Windows
         :sync: windows
 
-        .. figure:: https://help.agi.com/stkdevkit/Content/automationTree/images/Windows_Container_Heirarchy.png
+        .. figure:: https://help.agi.com/stkdevkit/Content/automationTree/images/Windows_Container_Hierarchy.png
 
     .. tab-item:: STK images for Linux
         :sync: linux


### PR DESCRIPTION
Updates the link to an image taken from the [https://help.agi.com](https://help.agi.com/). The name of the file just changed due to a typo on its filename. This fixes the nightly build, see failing session in https://github.com/ansys-internal/pystk/actions/runs/10085977916