### PR TITLE
fix: missing QUARTO_VERSION environment variable in ci_cd_night.yml

### DIFF
--- a/.github/workflows/ci_cd_night.yml
+++ b/.github/workflows/ci_cd_night.yml
@@ -29,6 +29,7 @@ env:
   STK_DOCKER_IMAGE: 'ansys/stk:dev-ubuntu22.04'
   PYSTK_DIR: '/home/stk/pystk'
   LICENSE_SERVER_PORT: '1055'
+  QUARTO_VERSION: '1.5.55'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Continuation of #424. Fixes the CI/CD by adding a missing environment variable in the `ci_cd_night.yml` file.