### PR TITLE
fix: pass APPDATA environment variable for quarto to work on Windows

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -120,6 +120,7 @@ passenv =
     BUILD_API
     BUILD_EXAMPLES
     DISPLAY
+    APPDATA
 extras = 
     doc
     visualization


### PR DESCRIPTION
Pass `APPDATA` environment variable on Windows as quarto requires it. Without it, it fails with the following error:

```
Rendering notebook as PDF[ 10%] aircraft-carrier-landing.ipynb
pandoc
  to: latex
  output-file: aircraft-carrier-landing.tex
  standalone: true
  pdf-engine: xelatex
  variables:
    graphics: true
    tables: true
  default-image-extension: pdf

metadata
  documentclass: scrartcl
  classoption:
    - DIV=11
    - numbers=noendperiod
  papersize: letter
  header-includes:
    - '\KOMAoption{captions}{tableheading}'
  block-headings: true
  title: Multi-aircraft carrier landing with Aviator
  highlight-style: pygments


Rendering PDF
running xelatex - 1
ERROR: Required environment variable APPDATA not specified.
```

