### PR TITLE
fix: eliminate assert statements

### DIFF
--- a/src/ansys/stk/core/internal/eventutil.py
+++ b/src/ansys/stk/core/internal/eventutil.py
@@ -37,13 +37,11 @@ class _EventSubscriptionManagerImpl(object):
     def subscribe(self, handler: STKEventSubscriber) -> int:
         self._next_id = self._next_id + 1
         self._handlers[self._next_id] = handler
-        assert(isinstance(handler, STKEventSubscriber))
         handler._subscribe_impl()
         return self._next_id
         
     def unsubscribe(self, id:int):
         if id in self._handlers:
-            assert(isinstance(self._handlers[id], STKEventSubscriber))
             self._handlers[id]._unsubscribe_impl()
             del(self._handlers[id])
         
@@ -71,8 +69,8 @@ class STKEventSubscriber(object):
             
     def _subscribe_impl(self):
         """Private method, called by EventSubscriptionManager"""
-        assert(isinstance(self._impl, COMEventHandlerImpl) or isinstance(self._impl, GrpcEventHandlerImpl))
-        self._impl.subscribe()
+        impl : COMEventHandlerImpl | GrpcEventHandlerImpl = self._impl
+        impl.subscribe()
         
     def unsubscribe(self):
         """Unsubscribe from events."""
@@ -82,8 +80,8 @@ class STKEventSubscriber(object):
             
     def _unsubscribe_impl(self):
         """Private method, called by EventSubscriptionManager"""
-        assert(isinstance(self._impl, COMEventHandlerImpl) or isinstance(self._impl, GrpcEventHandlerImpl))
-        self._impl.unsubscribe()
+        impl : COMEventHandlerImpl | GrpcEventHandlerImpl = self._impl
+        impl.unsubscribe()
         
 class _STKEvent(object):
     def __init__(self):

--- a/src/ansys/stk/core/internal/grpcutil.py
+++ b/src/ansys/stk/core/internal/grpcutil.py
@@ -198,12 +198,10 @@ class GrpcInterfacePimpl(object):
 
     @property
     def obj(self):
-        assert type(self._impl) != GrpcInterfaceFuture
         return self._impl.obj
 
     @property
     def client(self):
-        assert type(self._impl) != GrpcInterfaceFuture
         return self._impl.client
     
     def deactivate(self):

--- a/src/ansys/stk/core/stkdesktop.py
+++ b/src/ansys/stk/core/stkdesktop.py
@@ -142,8 +142,8 @@ class STKDesktopApplication(UiApplication):
     def shutdown(self) -> None:
         """Close this STK Desktop instance (or detach if the instance was obtained through STKDesktop.AttachToApplication())."""
         if self._root is not None:
-            assert(isinstance(self._root, StkObjectRoot))
-            self._root.close_scenario()
+            root : StkObjectRoot = self._root
+            root.close_scenario()
             self.__dict__["_root"] = None
         if hasattr(self._intf, "client"):
             self.user_control = False

--- a/src/ansys/stk/core/utilities/grpcutilities.py
+++ b/src/ansys/stk/core/utilities/grpcutilities.py
@@ -99,7 +99,8 @@ class GrpcCallBatcher(object):
     def start_batching(self) -> None:
         """Explicitly start batching until stop_batching() is called."""
         if not self._disable_batching and not self._batching:
-            assert self._initialized, "The GrpcCallBatcher should be obtained from the STK application rather than constructed directly."
+            if not self._initialized:
+                raise RuntimeError("The GrpcCallBatcher should be obtained from the STK application rather than constructed directly.")
             GrpcClient.register_call_batcher(self)
             self._batching = True
 


### PR DESCRIPTION
Address [`Bandit B101: assert_used`](https://bandit.readthedocs.io/en/1.7.9/plugins/b101_assert_used.html) warnings. Depending on the case, replaced by throwing an exception, remove the asserts, or added a type hint if the assert was added for migration to the new API.
