### PR TITLE
fix: use tox for building docs in ci_cd_main.yml

### DIFF
--- a/.github/workflows/ci_cd_main.yml
+++ b/.github/workflows/ci_cd_main.yml
@@ -20,10 +20,21 @@ jobs:
     timeout-minutes: 30
     steps:
 
-      - name: "Build project documentation excluding 'API' and 'Example' sections"
-        uses: ansys/actions/doc-build@v7
+      - name: "Checkout project"
+        uses: actions/checkout@v4
+
+      - name: "Install Python ${{ env.MAIN_PYTHON_VERSION }}"
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
+
+      - name: "Install Tox"
+        run: |
+          python -m pip install tox
+
+      - name: "Build project documentation excluding 'API' and 'Example' sections"
+        run: |
+          tox -e doc-links,doc-html
         env:
           BUILD_API: false
           BUILD_EXAMPLES: false


### PR DESCRIPTION
Fixes the issues found in https://github.com/ansys-internal/pystk/actions/runs/10611189297/job/29410183088 after merging https://github.com/ansys-internal/pystk/pull/489.

The reason behind this bug is that the documentation build process configure in `tox` and the one in `Makefile` and `make.bat` are out of sync. Related with #473.