### PR TITLE
fix: dependabot pull-request title prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,7 @@ updates:
     labels:
       - "dependencies:ci"
     commit-message:
-      prefix: "bump"
+      prefix: "build"
     groups:
       actions:
         patterns:


### PR DESCRIPTION
After merging #512, we are properly checking for pull-request titles to ensure conventional commits are used. Thus, `dependabot` prefix must be aligned with this convention.

Related with the CI/CD failures in https://github.com/ansys-internal/pystk/pull/523