### PR TITLE
fix: use snapshot data for capturing visual output in gallery of examples

### DIFF
--- a/src/ansys/stk/core/stkengine/experimental/jupyterwidgets.py
+++ b/src/ansys/stk/core/stkengine/experimental/jupyterwidgets.py
@@ -379,13 +379,8 @@ class WidgetBase(RemoteFrameBuffer):
         if not needs_snapshot:
             data = super()._repr_mimebundle_(include=include, exclude=exclude)
         else:
-            # TODO: find a better solution for flushing the scene
-            # https://github.com/ansys-internal/pystk/issues/530
-            import time
-            time.sleep(3)
-
             data = {
-                "image/png": array2png(self.get_frame())
+                "image/png": array2png(self.snapshot().data)
             }
         return data
 


### PR DESCRIPTION
This pull-request is related with https://github.com/ansys-internal/pystk/issues/530. It introduces an arbitrary delay of three seconds as a margin for the scene rendering prior capturing its state.
