### PR TITLE
fix: CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in the repo. Unless a
 # later match takes precedence, the PySTK team will be requested for review when
 # someone opens a pull request.
-*       @ansys-internal/pystk-team
+*       @ansys-internal/pystk-approvers


### PR DESCRIPTION
The original Team does not have write access. Only the PySTK Approvers can authorize the merge of a pull-request. Therefore, GitHub complains about PySTK Team being not a valid team in the CODEOWNERS file. This pull-request fixes this situation.