### PR TITLE
fix: doc build when tox generates warnings

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -323,7 +323,7 @@ jinja_globals = {
 
 jinja_contexts = {
     "toxenvs": {
-        "envs": subprocess.run(["tox", "list", "-d"], capture_output=True, text=True).stdout.splitlines()[1:],
+        "envs": subprocess.run(["tox", "list", "-d", "-q"], capture_output=True, text=True).stdout.splitlines()[1:],
     },
     "main_toctree": {
         "build_api": BUILD_API,


### PR DESCRIPTION
Run tox in quiet mode to avoid capturing unrelated warnings that could be generated by tox. This addresses the folowwing problem.

On my machine, tox generates a few warnings due to [PEP-514](https://peps.python.org/pep-0514/):

```console
(pytstk_venv) X:\...\pystk>tox list -d
build: PEP-514 violation in Windows Registry at HKEY_LOCAL_MACHINE/PythonCore/3.9 error: could not load exe with value C:\Program Files\Python39\python.exe
...
build: PEP-514 violation in Windows Registry at HKEY_CURRENT_USER/PythonCore/3.11/InstallPath error: missing
build: PEP-514 violation in Windows Registry at HKEY_CURRENT_USER/PythonCore/3.13/InstallPath error: missing
C:\Program Files\Python39\python.exe
default environments:
code-style                                      -> Checks project code style
tests-aviator-graphics-cov-linux                -> Checks for project testing with desired extras
etc.
```

These warnings are captured inside the `toxenvs` when we run the following command in `conf.py`:

```json
"toxenvs": {
    "envs": subprocess.run(["tox", "list", "-d"], capture_output=True, text=True).stdout.splitlines()[1:],
},
```

which later causes jinja to fail as `toxenvs` does not have the expected format:

```console
building [html]: targets for 0 source files that are out of date
updating environment: locale_dir D:\Dev\github_root\pystk2\doc\source\locales\en\LC_MESSAGES does not exist
[config changed ('jinja_contexts')] 24 added, 0 changed, 0 removed
reading sources... [  4%] artifacts
reading sources... [  8%] contribute
reading sources... [ 12%] contribute/developer

Traceback (most recent call last):
  File "D:\Dev\github_root\pystk2\.tox\doc-html\Lib\site-packages\sphinx\cmd\build.py", line 337, in build_main
    app.build(args.force_all, args.filenames)
  File "<template>", line 12, in top-level template code
...
ValueError: not enough values to unpack (expected 2, got 1)
```

Adding the `-q` option prevents the capture of the warnings and makes the documentation build more robust.
