### PR TITLE
fix: use Python 3.12 for nightly builds (as 3.13 currently seg faults)

### DIFF
--- a/.github/workflows/ci_cd_night.yml
+++ b/.github/workflows/ci_cd_night.yml
@@ -25,7 +25,7 @@ on:
 
 env:
   LIBRARY_NAME: 'ansys-stk-core'
-  MAIN_PYTHON_VERSION: '3.13'
+  MAIN_PYTHON_VERSION: '3.12'
   DOCUMENTATION_CNAME: 'stk.docs.pyansys.com'
   STK_DOCKER_IMAGE: 'ansys/stk:dev-ubuntu22.04'
   PYSTK_DIR: '/home/stk/pystk'


### PR DESCRIPTION
We are currently experiencing a segmentation fault when the tests run with Python 3.13 (for instance [log](https://github.com/ansys-internal/pystk/actions/runs/11714235876/job/32628535825#step:7:72)):

```
...
tests/generated/stk_tests/access/time_period_tests.py::TimePeriodTests::test_TimePeriod_09 PASSED [  2%]
tests/generated/stk_tests/access/time_period_tests.py::TimePeriodTests::test_TimePeriod_10 PASSED [  2%]
Fatal Python error: Segmentation fault
```

Temporarily switching to 3.12 for the time being until we resolve the issue with 3.13.