### PR TITLE
fix: refactor host string check to eliminate warning in bandit report

### DIFF
--- a/src/ansys/stk/core/stkdesktop.py
+++ b/src/ansys/stk/core/stkdesktop.py
@@ -222,9 +222,9 @@ class STKDesktop(object):
             # Calling subprocess.Popen (without shell equals true) to start the backend. 
             # Excluding low severity bandit check as the validity of the inputs has been ensured.
             app_process = subprocess.Popen(cmd_line) # nosec B603
+            host = grpc_host
             # Ignoring B104 warning as it is a false positive. The hardcoded string "0.0.0.0" is being filtered
             # to ensure that it is not used.
-            host = grpc_host
             if host=="0.0.0.0": # nosec B104
                 host = "localhost"
             app = STKDesktop.attach_to_application(None, grpc_server, host, grpc_port, grpc_timeout_sec)

--- a/src/ansys/stk/core/stkruntime.py
+++ b/src/ansys/stk/core/stkruntime.py
@@ -161,9 +161,9 @@ class STKRuntime(object):
         # Calling subprocess.Popen (without shell equals true) to start the backend. 
         # Excluding low severity bandit check as the validity of the inputs has been ensured.
         subprocess.Popen(cmd_line) # nosec B603
+        host = grpc_host
         # Ignoring B104 warning as it is a false positive. The hardcoded string "0.0.0.0" is being filtered
         # to ensure that it is not used.
-        host = grpc_host
         if host=="0.0.0.0": # nosec B104
             host = "localhost"
         app = STKRuntime.attach_to_application(host, grpc_port, grpc_timeout_sec)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/eeeea347-ecc7-4b98-92be-83e618ac3e29)
Bandit was a reporting a warning that no tests were failed where `# nosec B104` exclusions were added but removing the exclusion led to the test failing. 

Refactoring the host string check into two different lines should prevent the warning from appearing during vulnerability checks during CI/CD while passing the B104 check.