### PR TITLE
fix: rendering of Date object in API reference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ tests = [
     "numpy==2.1.3"
 ]
 doc = [
-    "ansys-sphinx-theme==1.2.2",
+    "ansys-sphinx-theme==1.2.3",
     "build==1.2.2.post1",
     "jupyterlab==4.3.1",
     "jupytext==1.16.4",


### PR DESCRIPTION
Fix #548 by updating the Ansys Sphinx Theme to its latest version.