### PR TITLE
fix: exclude link from link check

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -171,6 +171,7 @@ linkcheck_ignore = [
     f"https://github.com/{user_repo}/*",
     "https://support.agi.com/3d-models",
     "https://support.agi.com/downloads",
+    "https://www.khronos.org/collada/",
 ]
 
 # -- Declare the Jinja context -----------------------------------------------


### PR DESCRIPTION
Excluding https://www.khronos.org/collada/ from link check as it is failing due to the web page verifying that it is accessed by a human.