### PR TITLE
fix: remove docker compose version specification

### DIFF
--- a/docker/linux/ubuntu/docker-compose.yml
+++ b/docker/linux/ubuntu/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
 
   stk:

--- a/docker/linux/ubuntu/stk-engine-py311/docker-compose.yml
+++ b/docker/linux/ubuntu/stk-engine-py311/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   stk-python3.11:
     image: ansys/stk:dev-ubuntu22.04-python3.11

--- a/docker/linux/ubuntu/stk-engine-py312/docker-compose.yml
+++ b/docker/linux/ubuntu/stk-engine-py312/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   stk-python3.12:
     image: ansys/stk:dev-ubuntu22.04-python3.12

--- a/docker/linux/ubuntu/stk-engine-py313/docker-compose.yml
+++ b/docker/linux/ubuntu/stk-engine-py313/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   stk-python3.13:
     image: ansys/stk:dev-ubuntu22.04-python3.13

--- a/docker/linux/ubuntu/stk-engine-pybase/docker-compose.yml
+++ b/docker/linux/ubuntu/stk-engine-pybase/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   stk-python-common:
     image: ansys/stk:dev-ubuntu22.04-python-common

--- a/docker/linux/ubuntu/stk-engine/docker-compose.yml
+++ b/docker/linux/ubuntu/stk-engine/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   stk:
     image: ansys/stk:dev-ubuntu22.04

--- a/docker/windows/docker-compose.yml
+++ b/docker/windows/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
 
   stk:

--- a/docker/windows/stk-engine-py311/docker-compose.yml
+++ b/docker/windows/stk-engine-py311/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   stk-python3.111:
     image: ansys/stk:dev-windowsservercore-ltsc2019-python3.11

--- a/docker/windows/stk-engine-py312/docker-compose.yml
+++ b/docker/windows/stk-engine-py312/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   stk-python3.12:
     image: ansys/stk:dev-windowsservercore-ltsc2019-python3.12

--- a/docker/windows/stk-engine-py313/docker-compose.yml
+++ b/docker/windows/stk-engine-py313/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   stk-python3.13:
     image: ansys/stk:dev-windowsservercore-ltsc2019-python3.13

--- a/docker/windows/stk-engine-pybase/docker-compose.yml
+++ b/docker/windows/stk-engine-pybase/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   stk-pybase:
     image: ansys/stk:dev-windowsservercore-ltsc2019-pybase

--- a/docker/windows/stk-engine/docker-compose.yml
+++ b/docker/windows/stk-engine/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   stk:
     image: ansys/stk:dev-windowsservercore-ltsc2019


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/02702c7a-6ce9-4174-ab7b-a5e698daa9aa)

The `version` property is now obsolete in Docker Compose V2.

It is recommended to remove the property `docker-compose.yml` files to avoid warnings like the one pictured above.