### PR TITLE
fix: make sure the id for the data table is unique

### DIFF
--- a/doc/source/user-guide/migration.rst
+++ b/doc/source/user-guide/migration.rst
@@ -168,7 +168,7 @@ The table below lists the interface, classes, enumerations, and method names tha
 
 .. raw:: html
 
-    <table class="datatable table dataTable no-footer display" id="migration-table" role="grid" aria-describedby="DataTables_{{ module | replace('.', '_') }}_info">
+    <table class="datatable table dataTable no-footer display" id="js-migration-table" role="grid" aria-describedby="DataTables_{{ module | replace('.', '_') }}_info">
       <thead>
         <tr class="row-odd" role="row">
           <th class="head sorting_asc" tabindex="0" aria-controls="migration-table" rowspan="1" colspan="1" aria-sort="ascending" aria-label="Old name activate to sort column descending" style="width: 153.312px;">
@@ -194,12 +194,12 @@ The table below lists the interface, classes, enumerations, and method names tha
             .then(function (data) {
 
                 // If DataTable is already initialized, destroy it first to reset the table
-                if ($.fn.dataTable.isDataTable('#migration-table')) {
-                    $('#migration-table').DataTable().clear().destroy();
+                if ($.fn.dataTable.isDataTable('#js-migration-table')) {
+                    $('#js-migration-table').DataTable().clear().destroy();
                 }
 
                 // Initialize the table with desired options
-                migrationTable = $("#migration-table").DataTable({
+                migrationTable = $("#js-migration-table").DataTable({
                     ordering: true,
                     language: {
                         emptyTable: "Loading..."


### PR DESCRIPTION
The addition of the migration instructions to this page introduced a new section labeled "Migration table", for which Sphinx automatically generates an id named "migration-table". That id conflicted with the id for the data table. Changed the data table id to "js-data-table" to resolve the conflict. The data table failed to initialize from JavaScript and was producing the following popup:

![image](https://github.com/user-attachments/assets/aa0aef2f-1a9e-4f67-9372-0573a4ad3b92)


