### PR TITLE
fix: label used in labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -26,7 +26,7 @@
           - any-glob-to-any-file: ['examples/**/*.py', 'doc/source/examples.rst']
 
 ## -- Other labels ------------------------------------------------------------
-'code-style':
+'style:code':
   - any:
       - changed-files:
           - any-glob-to-any-file: ['.pre-commit-config.yaml', 'doc/.vale.ini']


### PR DESCRIPTION
Replace `code-style` with `style:code` label. Otherwise, this may cause CI/CD issues with the labeler action.