### PR TITLE
docs: show how to display scenarios

### DIFF
--- a/examples/create-load-scenarios.py
+++ b/examples/create-load-scenarios.py
@@ -58,6 +58,7 @@ propagator.propagate()  # To propagate the orbit
 # +
 from ansys.stk.core.stkengine.experimental.jupyterwidgets import GlobeWidget
 
+
 plotter = GlobeWidget(root, 640, 480)
 plotter.show()
 # -


### PR DESCRIPTION
Fix #678 by adding a short section on how to display a scenario. This ensures some graphic output is present and thus, captured for using it as thumbnail in the gallery of examples.