### PR TITLE
feat(labels): add blocked label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -64,3 +64,8 @@
   - all:
       - changed-files:
           - all-globs-to-all-files: ['THIS-NEVER-MATCHES-A-FILE']
+
+'blocked':
+  - all:
+      - changed-files:
+          - all-globs-to-all-files: ['THIS-NEVER-MATCHES-A-FILE']

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -106,3 +106,7 @@
 - name: 'docker'
   description: Docker maintenance related
   color: 000075
+
+- name: 'blocked'
+  description: Cannot be completed until other tasks are resolved
+  color: 000000


### PR DESCRIPTION
This pull-request adds a `blocked` label. Its purpose is to help identifying issues and pull-requests that can not be solved or merged until other tasks are completed first.