### PR TITLE
fix(doc): restore linkcheck for changelog

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -186,9 +186,6 @@ linkcheck_ignore = [
     # TODO: Determine a way to link to examples without breaking the linkcheck
     # https://github.com/ansys/pystk/issues/657
     r"../examples/",
-    # TODO: changelog links
-    # https://github.com/ansys/pystk/issues/706
-    f"https://github.com/ansys/{html_context['github_repo']}/*",
 ]
 
 # -- Declare the Jinja context -----------------------------------------------


### PR DESCRIPTION
Fix #706 by restoring linkcheck support for the changelog pages now that the project is public.