### PR TITLE
fix: pin typer package to prevent AttributeError

### DIFF
--- a/doc/source/changelog/807.fixed.md
+++ b/doc/source/changelog/807.fixed.md
@@ -1,0 +1,1 @@
+Pin typer package to prevent AttributeError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ migration = [
 vulnerabilities = [
     "bandit[toml]==1.8.6",
     "safety==3.6.0",
+    "typer==0.16.1",
 ]
 tests = [
     "numpy==2.2.6",


### PR DESCRIPTION
Pin the typer module to avoid AttributeError below with the latest release. See [log ](https://github.com/ansys/pystk/actions/runs/17344158472/job/49241964015#step:6:42)for an example of failure.

```
vulnerabilities-deps: commands[0]> safety check -o bare --continue-on-error -i 67599 --save-json /home/runner/work/pystk/pystk/log/safety.json
Traceback (most recent call last):
  File "/home/runner/work/pystk/pystk/.tox/vulnerabilities-deps/bin/safety", line 3, in <module>
    from safety.cli import cli
  File "/home/runner/work/pystk/pystk/.tox/vulnerabilities-deps/lib/python3.13/site-packages/safety/cli.py", line 1250, in <module>
    typer.rich_utils.STYLE_HELPTEXT = ""
    ^^^^^^^^^^^^^^^^
AttributeError: module 'typer' has no attribute 'rich_utils'
```