### PR TITLE
chore(pyproject): update classifiers to include Python 3.10

### DIFF
--- a/doc/source/changelog/808.maintenance.md
+++ b/doc/source/changelog/808.maintenance.md
@@ -1,0 +1,1 @@
+Update classifiers to include Python 3.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
This pull-request includes the classifier for Pyhton 3.10 support in the `pyproject.toml` file.