### PR TITLE
fix(ci): remove duplicated commands

### DIFF
--- a/.github/workflows/ci_cd_release.yml
+++ b/.github/workflows/ci_cd_release.yml
@@ -292,7 +292,6 @@ jobs:
           docker exec \
             --workdir ${{ env.PYSTK_DIR }} \
             "${STK_CONTAINER}" /bin/bash -c \
-            "export COVERAGE_FILE=.cov/extensions && tox -e tests-extensions-cov"
             "export COVERAGE_FILE=.cov/migration && tox -e tests-core-migration-cov"
 
       - name: "Run the aviator tests"
@@ -311,7 +310,6 @@ jobs:
           docker exec \
             --workdir ${{ env.PYSTK_DIR }} \
             "${STK_CONTAINER}" /bin/bash -c \
-            "export COVERAGE_FILE=.cov/aviator && tox -e tests-core-aviator-graphics-cov-linux"
             "export COVERAGE_FILE=.cov/stknogfx && tox -e tests-core-stk-nographics-cov-linux"
 
       - name: "Run the graphics only stk tests"


### PR DESCRIPTION
Removes the duplicated commands in the `ci_cd_relase.yml`, see this failing CI/CD run:

https://github.com/ansys/pystk/actions/runs/17494978348/job/49693479977
