### PR TITLE
Fix building the STK docker images with latest docker which uses Bake

### DIFF
--- a/docker/linux/ubuntu/docker-compose.yml
+++ b/docker/linux/ubuntu/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       context: ./stk-engine-pybase
       args:
         baseImage: ansys/stk-12.10:dev-ubuntu22.04
+      additional_contexts:
+        "ansys/stk-12.10:dev-ubuntu22.04": "service:stk"
     environment:
       - ANSYSLMD_LICENSE_FILE=$ANSYSLMD_LICENSE_FILE
 
@@ -32,6 +34,9 @@ services:
       args:
         baseImage: ansys/stk-12.10:dev-ubuntu22.04
         basePythonImage: ansys/stk-12.10:dev-ubuntu22.04-pybase
+      additional_contexts:
+        "ansys/stk-12.10:dev-ubuntu22.04": "service:stk"
+        "ansys/stk-12.10:dev-ubuntu22.04-pybase": "service:stk-pybase"
     environment:
       - ANSYSLMD_LICENSE_FILE=$ANSYSLMD_LICENSE_FILE
 
@@ -45,6 +50,9 @@ services:
       args:
         baseImage: ansys/stk-12.10:dev-ubuntu22.04
         basePythonImage: ansys/stk-12.10:dev-ubuntu22.04-pybase
+      additional_contexts:
+        "ansys/stk-12.10:dev-ubuntu22.04": "service:stk"
+        "ansys/stk-12.10:dev-ubuntu22.04-pybase": "service:stk-pybase"
     environment:
       - ANSYSLMD_LICENSE_FILE=$ANSYSLMD_LICENSE_FILE
 
@@ -58,6 +66,9 @@ services:
       args:
         baseImage: ansys/stk-12.10:dev-ubuntu22.04
         basePythonImage: ansys/stk-12.10:dev-ubuntu22.04-pybase
+      additional_contexts:
+        "ansys/stk-12.10:dev-ubuntu22.04": "service:stk"
+        "ansys/stk-12.10:dev-ubuntu22.04-pybase": "service:stk-pybase"
     environment:
       - ANSYSLMD_LICENSE_FILE=$ANSYSLMD_LICENSE_FILE
 
@@ -71,7 +82,8 @@ services:
       args:
         baseImage: ansys/stk-12.10:dev-ubuntu22.04
         basePythonImage: ansys/stk-12.10:dev-ubuntu22.04-pybase
+      additional_contexts:
+        "ansys/stk-12.10:dev-ubuntu22.04": "service:stk"
+        "ansys/stk-12.10:dev-ubuntu22.04-pybase": "service:stk-pybase"
     environment:
       - ANSYSLMD_LICENSE_FILE=$ANSYSLMD_LICENSE_FILE
-
-

--- a/docker/linux/ubuntu/stk-engine-py310/Dockerfile
+++ b/docker/linux/ubuntu/stk-engine-py310/Dockerfile
@@ -1,7 +1,7 @@
 # By default, start from the base STK Engine Python image
 ARG baseImage=ansys/stk-12.10:dev-ubuntu22.04
 ARG basePythonImage=ansys/stk-12.10:dev-ubuntu22.04-pybase
-FROM ${basePythonImage} as builder
+FROM ${basePythonImage} AS builder
 
 ##############################################
 # 1) Build Python into its own builder stage

--- a/docker/linux/ubuntu/stk-engine-py311/Dockerfile
+++ b/docker/linux/ubuntu/stk-engine-py311/Dockerfile
@@ -1,7 +1,7 @@
 # By default, start from the base STK Engine Python image
 ARG baseImage=ansys/stk-12.10:dev-ubuntu22.04
 ARG basePythonImage=ansys/stk-12.10:dev-ubuntu22.04-pybase
-FROM ${basePythonImage} as builder
+FROM ${basePythonImage} AS builder
 
 ##############################################
 # 1) Build Python into its own builder stage

--- a/docker/linux/ubuntu/stk-engine-py312/Dockerfile
+++ b/docker/linux/ubuntu/stk-engine-py312/Dockerfile
@@ -1,7 +1,7 @@
 # By default, start from the base STK Engine Python image
 ARG baseImage=ansys/stk-12.10:dev-ubuntu22.04
 ARG basePythonImage=ansys/stk-12.10:dev-ubuntu22.04-pybase
-FROM ${basePythonImage} as builder
+FROM ${basePythonImage} AS builder
 
 ##############################################
 # 1) Build Python into its own builder stage

--- a/docker/linux/ubuntu/stk-engine-py313/Dockerfile
+++ b/docker/linux/ubuntu/stk-engine-py313/Dockerfile
@@ -1,7 +1,7 @@
 # By default, start from the base STK Engine Python image
 ARG baseImage=ansys/stk-12.10:dev-ubuntu22.04
 ARG basePythonImage=ansys/stk-12.10:dev-ubuntu22.04-pybase
-FROM ${basePythonImage} as builder
+FROM ${basePythonImage} AS builder
 
 ##############################################
 # 1) Build Python into its own builder stage

--- a/docker/windows/stk-engine-py310/Dockerfile
+++ b/docker/windows/stk-engine-py310/Dockerfile
@@ -1,7 +1,7 @@
 # By default, start from the base STK Engine Python image
 ARG baseImage=ansys/stk-12.10:dev-windowsservercore-ltsc2019
 ARG basePythonImage=ansys/stk-12.10:dev-windowsservercore-ltsc2019-pybase
-FROM ${basePythonImage} as builder
+FROM ${basePythonImage} AS builder
 
 USER ContainerAdministrator
 

--- a/docker/windows/stk-engine-py311/Dockerfile
+++ b/docker/windows/stk-engine-py311/Dockerfile
@@ -1,7 +1,7 @@
 # By default, start from the base STK Engine Python image
 ARG baseImage=ansys/stk-12.10:dev-windowsservercore-ltsc2019
 ARG basePythonImage=ansys/stk-12.10:dev-windowsservercore-ltsc2019-pybase
-FROM ${basePythonImage} as builder
+FROM ${basePythonImage} AS builder
 
 USER ContainerAdministrator
 

--- a/docker/windows/stk-engine-py312/Dockerfile
+++ b/docker/windows/stk-engine-py312/Dockerfile
@@ -1,6 +1,6 @@
 # By default, start from the base STK Engine Python image
 ARG basePythonImage=ansys/stk-12.10:dev-windowsservercore-ltsc2019-pybase
-FROM ${basePythonImage} as builder
+FROM ${basePythonImage} AS builder
 
 USER ContainerAdministrator
 

--- a/docker/windows/stk-engine-py313/Dockerfile
+++ b/docker/windows/stk-engine-py313/Dockerfile
@@ -1,6 +1,6 @@
 # By default, start from the base STK Engine Python image
 ARG basePythonImage=ansys/stk-12.10:dev-windowsservercore-ltsc2019-pybase
-FROM ${basePythonImage} as builder
+FROM ${basePythonImage} AS builder
 
 USER ContainerAdministrator
 

--- a/tox.ini
+++ b/tox.ini
@@ -250,13 +250,13 @@ setenv =
     # Ubuntu container
     ubuntu_container: CONTAINER_OS = ubuntu22.04
     ubuntu_container: CONTAINER_ARGS = --volume "{toxinidir}:/home/stk/pystk"
-    ubuntu_container: CONTAINER_CMD = /bin/bash -c "cd /home/stk && python -m venv .venv && source .venv/bin/activate && python -m pip install --upgrade pip && python -m pip install -e /home/stk/pystk[jupyter] && cd /home/stk/pystk && python -m pip install --group tests . && python -m pip install --group doc ."
+    ubuntu_container: CONTAINER_CMD = /bin/bash -c "cd /home/stk && python -m venv .venv && source .venv/bin/activate && python -m pip install --upgrade pip && python -m pip install -e /home/stk/pystk[all] && cd /home/stk/pystk && python -m pip install --group tests . && python -m pip install --group doc ."
     ubuntu_container: WINDOWS_HOST_ROOT_CMD = /bin/bash -c "chown -R stk:stk /home/stk/pystk/tests"
     ubuntu_container: ROOT_USER = root
     # Windows container
     windows_container: CONTAINER_OS = windowsservercore-ltsc2019
     windows_container: CONTAINER_ARGS = --volume "{toxinidir}:C:\Users\STK\pystk"
-    windows_container: CONTAINER_CMD = cmd /C "python -m venv .venv && cd pystk && chcp 65001 && call C:\Users\STK\.venv\Scripts\activate.bat && python -m pip install --upgrade pip && python -m pip install -e C:\Users\STK\pystk[jupyter]  && python -m pip install --group tests . && python -m pip install --group doc ."
+    windows_container: CONTAINER_CMD = cmd /C "python -m venv .venv && cd pystk && chcp 65001 && call C:\Users\STK\.venv\Scripts\activate.bat && python -m pip install --upgrade pip && python -m pip install -e C:\Users\STK\pystk[all]  && python -m pip install --group tests . && python -m pip install --group doc ."
     windows_container: WINDOWS_HOST_ROOT_CMD = cmd /C "takeown /F C:\Users\STK\pystk\tests /R /D Y 2> nul"
     windows_container: ROOT_USER = STK
 allowlist_externals =


### PR DESCRIPTION
Latest versions of Docker promoted Bake as the default build tool for Compose ([release notes](https://docs.docker.com/compose/releases/release-notes/#2362)). Bake tries to build the images in parallel which fails with the error below. Added `additional_contexts` declarations to the STK Ubuntu Docker compose file to declare the dependencies between the various images, hence defining the build order. See the [Use another service's image as the base image](https://docs.docker.com/compose/how-tos/dependent-images/#use-another-services-image-as-the-base-image) section in the Docker Compose documentation.

Also fixed a few minor [FromAsCasing](https://docs.docker.com/reference/build-checks/from-as-casing/) docker warnings, and installed more dependencies as part of building the [STK container images with tox](https://github.com/ansys/pystk/blob/main/CONTRIBUTING.md#building-the-stk-container-images-with-tox) to allow to follow the steps in [CONTRIBUTING.md](https://github.com/ansys/pystk/blob/main/CONTRIBUTING.md) to run the [doc_snippets_tests initialisation tests](https://github.com/ansys/pystk/blob/main/tests/doc_snippets_tests/initialization/initialization_snippets.py) which require grpc.

```
------
 > [stk-python3_13 internal] load metadata for docker.io/ansys/stk-12.10:dev-ubuntu22.04:
------
Dockerfile:3

--------------------

   1 |     # By default, start from the base STK Engine image

   2 |     ARG baseImage=ansys/stk-12.10:dev-ubuntu22.04

   3 | >>> FROM ${baseImage}

   4 |

   5 |     # Install system dependencies

--------------------

target stk-pybase: failed to solve: ansys/stk-12.10:dev-ubuntu22.04:
failed to resolve source metadata for docker.io/ansys/stk-12.10:dev-ubuntu22.04:
pull access denied, repository does not exist or may require authorization: server message:
insufficient_scope: authorization failed
```