### PR TITLE
fix(ci): missing environment variable

### DIFF
--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -296,6 +296,8 @@ jobs:
         if: |
           contains(github.event.pull_request.labels.*.name, 'docs:examples') &&
           !contains(github.event.pull_request.labels.*.name, 'docs:api')
+        env:
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${{ env.PYSTK_DIR }} \


### PR DESCRIPTION
This pull-request adds a missing environment variable that caused [this CI/CD run](https://github.com/ansys/pystk/actions/runs/17572858721/job/49912341742) to fail when building the documentation examples.