### PR TITLE
fix(ci): use runner name when starting a new container

### DIFF
--- a/.github/workflows/ci_cd_night.yml
+++ b/.github/workflows/ci_cd_night.yml
@@ -92,29 +92,31 @@ jobs:
 
       - name: "Generate the name of the Docker image and the container"
         id: docker
+        env:
+          RUNNER: ${{ env.RUNNER_NAME }}
         run: |
           image_name="${STK_DOCKER_IMAGE}-python${MAIN_PYTHON_VERSION}"
+          container_name="stk-python${MAIN_PYTHON_VERSION}-${RUNNER}"
           echo "image=${image_name}" >> "${GITHUB_OUTPUT}"
+          echo "container=${container_name}" >> "${GITHUB_OUTPUT}"
 
       - name: "Start the container from the desired image"
-        id: container
         env:
           STK_IMAGE: ${{ steps.docker.outputs.image }}
+          STK_CONTAINER: ${{ steps.docker.outputs.image }}
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
         run: |
           docker run \
             --detach -it \
             --network="host" \
+            --name="${STK_CONTAINER}" \
             --env ANSYSLMD_LICENSE_FILE="${LICENSE_SERVER_PORT}@${LICENSE_SERVER}" \
             --volume ${PWD}:/home/stk/pystk \
             "${STK_IMAGE}"
 
-          container_name=$(docker ps --latest --format "{{.Names}}")
-          echo "name=${container_name}" >> "${GITHUB_OUTPUT}"
-
       - name: "Install system dependencies required for building examples"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --user root \
@@ -140,7 +142,7 @@ jobs:
 
       - name: "Install Tox"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -149,7 +151,7 @@ jobs:
 
       - name: "Build the full documentation"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -165,7 +167,7 @@ jobs:
       - name: "Stop the container"
         if: always()
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker stop "${STK_CONTAINER}"
           docker logs "${STK_CONTAINER}"
@@ -199,14 +201,18 @@ jobs:
 
       - name: "Generate the name of the Docker image and the container"
         id: docker
+        env:
+          RUNNER: ${{ env.RUNNER_NAME }}
         run: |
-          image_name=${STK_DOCKER_IMAGE}-python${MAIN_PYTHON_VERSION}
+          image_name="${STK_DOCKER_IMAGE}-python${MAIN_PYTHON_VERSION}"
+          container_name="stk-python${MAIN_PYTHON_VERSION}-${RUNNER}"
           echo "image=${image_name}" >> "${GITHUB_OUTPUT}"
+          echo "container=${container_name}" >> "${GITHUB_OUTPUT}"
 
       - name: "Start the container from the desired image"
-        id: container
         env:
           STK_IMAGE: ${{ steps.docker.outputs.image }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
         run: |
           docker run \
@@ -222,7 +228,7 @@ jobs:
 
       - name: "Install the project with the testing dependencies"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -231,7 +237,7 @@ jobs:
 
       - name: "Install coverage dependencies"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -242,7 +248,7 @@ jobs:
 
       - name: "Run the extensions tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -251,7 +257,7 @@ jobs:
 
       - name: "Run the API migration assistant tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -260,7 +266,7 @@ jobs:
 
       - name: "Run the aviator tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -269,7 +275,7 @@ jobs:
 
       - name: "Run the non graphics stk tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -278,7 +284,7 @@ jobs:
 
       - name: "Run the graphics only stk tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -287,7 +293,7 @@ jobs:
 
       - name: "Run the vgt tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -296,7 +302,7 @@ jobs:
 
       - name: "Run the doc snippet tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -308,7 +314,7 @@ jobs:
       - name: "Combine all coverage results"
         if: ${{ matrix.python == env.MINIMUM_PYTHON_VERSION }}
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR}/.cov \
@@ -318,7 +324,7 @@ jobs:
       - name: "Generate coverage report in XML and HTML"
         if: ${{ matrix.python == env.MINIMUM_PYTHON_VERSION }}
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -346,7 +352,7 @@ jobs:
       - name: "Stop the container"
         if: always()
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker stop "${STK_CONTAINER}"
           docker logs "${STK_CONTAINER}"

--- a/.github/workflows/ci_cd_night.yml
+++ b/.github/workflows/ci_cd_night.yml
@@ -93,7 +93,7 @@ jobs:
       - name: "Generate the name of the Docker image and the container"
         id: docker
         env:
-          RUNNER: ${{ env.RUNNER_NAME }}
+          RUNNER: ${{ runner.name }}
         run: |
           image_name="${STK_DOCKER_IMAGE}-python${MAIN_PYTHON_VERSION}"
           container_name="stk-python${MAIN_PYTHON_VERSION}-${RUNNER}"
@@ -202,7 +202,7 @@ jobs:
       - name: "Generate the name of the Docker image and the container"
         id: docker
         env:
-          RUNNER: ${{ env.RUNNER_NAME }}
+          RUNNER: ${{ runner.name }}
         run: |
           image_name="${STK_DOCKER_IMAGE}-python${MAIN_PYTHON_VERSION}"
           container_name="stk-python${MAIN_PYTHON_VERSION}-${RUNNER}"

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -229,7 +229,7 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'docs:examples')
         id: docker
         env:
-          RUNNER: ${{ env.RUNNER_NAME }}
+          RUNNER: ${{ runner.name }}
         run: |
           image_name="${STK_DOCKER_IMAGE}-python${MAIN_PYTHON_VERSION}"
           container_name="stk-python${MAIN_PYTHON_VERSION}-${RUNNER}"
@@ -428,7 +428,7 @@ jobs:
         id: docker
         env:
           PYTHON_VERSION: ${{ matrix.python }}
-          RUNNER: ${{ env.RUNNER_NAME }}
+          RUNNER: ${{ runner.name }}
         run: |
           image_name="${STK_DOCKER_IMAGE}-python${PYTHON_VERSION}"
           container_name="stk-python${PYTHON_VERSION}-${RUNNER}"

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -444,7 +444,7 @@ jobs:
           docker run \
             --detach -it \
             --network="host" \
-            --name="${STK_CONTAINER}"
+            --name="${STK_CONTAINER}" \
             --env ANSYSLMD_LICENSE_FILE="${LICENSE_SERVER_PORT}@${LICENSE_SERVER}" \
             --volume ${PWD}:/home/stk/pystk \
             "${STK_IMAGE}"

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -228,33 +228,35 @@ jobs:
         if: |
           contains(github.event.pull_request.labels.*.name, 'docs:examples')
         id: docker
+        env:
+          RUNNER: ${{ env.RUNNER_NAME }}
         run: |
-          image_name=${STK_DOCKER_IMAGE}-python${MAIN_PYTHON_VERSION}
+          image_name="${STK_DOCKER_IMAGE}-python${MAIN_PYTHON_VERSION}"
+          container_name="stk-python${MAIN_PYTHON_VERSION}-${RUNNER}"
           echo "image=${image_name}" >> "${GITHUB_OUTPUT}"
+          echo "container=${container_name}" >> "${GITHUB_OUTPUT}"
 
       - name: "Start the container from the desired image"
         if: |
           contains(github.event.pull_request.labels.*.name, 'docs:examples')
-        id: container
         env:
           STK_IMAGE: ${{ steps.docker.outputs.image }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
         run: |
           docker run \
             --detach -it \
             --network="host" \
+            --name="${STK_CONTAINER}" \
             --env ANSYSLMD_LICENSE_FILE="${LICENSE_SERVER_PORT}@${LICENSE_SERVER}" \
             --volume ${PWD}:/home/stk/pystk \
             "${STK_IMAGE}"
-
-          container_name=$(docker ps --latest --format "{{.Names}}")
-          echo "name=${container_name}" >> "${GITHUB_OUTPUT}"
 
       - name: "Install system dependencies required for building examples"
         if: |
           contains(github.event.pull_request.labels.*.name, 'docs:examples')
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --user root \
@@ -280,7 +282,7 @@ jobs:
 
       - name: "Install Tox in the GitHub runner or the self-hosted runner"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
           NEEDS_SELF_HOSTED_RUNNER: ${{ contains(github.event.pull_request.labels.*.name, 'docs:examples') }}
         run: |
           if [[ "${NEEDS_SELF_HOSTED_RUNNER}" == "true" ]]; then
@@ -302,7 +304,7 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'docs:examples') &&
           !contains(github.event.pull_request.labels.*.name, 'docs:api')
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -336,7 +338,7 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'docs:examples') &&
           contains(github.event.pull_request.labels.*.name, 'docs:api')
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -389,7 +391,7 @@ jobs:
       - name: "Stop the container"
         if: always()
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
           NEEDS_SELF_HOSTED_RUNNER: ${{ contains(github.event.pull_request.labels.*.name, 'docs:examples') }}
         run: |
           if [[ "${NEEDS_SELF_HOSTED_RUNNER}" == "true" ]]; then
@@ -426,29 +428,30 @@ jobs:
         id: docker
         env:
           PYTHON_VERSION: ${{ matrix.python }}
+          RUNNER: ${{ env.RUNNER_NAME }}
         run: |
-          image_name=${STK_DOCKER_IMAGE}-python${PYTHON_VERSION}
+          image_name="${STK_DOCKER_IMAGE}-python${PYTHON_VERSION}"
+          container_name="stk-python${PYTHON_VERSION}-${RUNNER}"
           echo "image=${image_name}" >> "${GITHUB_OUTPUT}"
+          echo "container=${container_name}" >> "${GITHUB_OUTPUT}"
 
       - name: "Start the container from the desired image"
         env:
           STK_IMAGE: ${{ steps.docker.outputs.image }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
-        id: container
         run: |
           docker run \
             --detach -it \
             --network="host" \
+            --name="${STK_CONTAINER}"
             --env ANSYSLMD_LICENSE_FILE="${LICENSE_SERVER_PORT}@${LICENSE_SERVER}" \
             --volume ${PWD}:/home/stk/pystk \
             "${STK_IMAGE}"
 
-          container_name=$(docker ps --latest --format "{{.Names}}")
-          echo "name=${container_name}" >> "${GITHUB_OUTPUT}"
-
       - name: "Install the project with the testing dependencies"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -457,7 +460,7 @@ jobs:
 
       - name: "Install coverage dependencies"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -466,7 +469,7 @@ jobs:
 
       - name: "Run the extensions tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -475,7 +478,7 @@ jobs:
 
       - name: "Run the API migration assistant tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -484,7 +487,7 @@ jobs:
 
       - name: "Run the aviator tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -493,7 +496,7 @@ jobs:
 
       - name: "Run the non graphics stk tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -502,7 +505,7 @@ jobs:
 
       - name: "Run the graphics only stk tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -511,7 +514,7 @@ jobs:
 
       - name: "Run the vgt tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -520,7 +523,7 @@ jobs:
 
       - name: "Run the doc snippet tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -532,7 +535,7 @@ jobs:
       - name: "Combine all coverage results"
         if: ${{ matrix.python == env.MINIMUM_PYTHON_VERSION }}
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR}/.cov \
@@ -542,7 +545,7 @@ jobs:
       - name: "Generate coverage report in XML and HTML"
         if: ${{ matrix.python == env.MINIMUM_PYTHON_VERSION }}
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -570,7 +573,7 @@ jobs:
       - name: "Stop the container"
         if: always()
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker stop "${STK_CONTAINER}"
           docker logs "${STK_CONTAINER}"

--- a/.github/workflows/ci_cd_release.yml
+++ b/.github/workflows/ci_cd_release.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: "Generate the name of the Docker image and the container"
         env:
-          RUNNER: ${{ env.RUNNER_NAME }}
+          RUNNER: ${{ runner.name }}
         run: |
           image_name="${STK_DOCKER_IMAGE}-python${MAIN_PYTHON_VERSION}"
           docker_name="stk-python${MAIN_PYTHON_VERSION}"
@@ -241,7 +241,7 @@ jobs:
         id: docker
         env:
           PYTHON: python-${{ matrix.python }}
-          RUNNER: ${{ env.RUNNER_NAME }}
+          RUNNER: ${{ runner.name }}
         run: |
           python_image_name="${STK_DOCKER_IMAGE}-${PYTHON}"
           container_name="stk-python${PYTHON}-${RUNNER}"

--- a/.github/workflows/ci_cd_release.yml
+++ b/.github/workflows/ci_cd_release.yml
@@ -142,9 +142,9 @@ jobs:
           RUNNER: ${{ runner.name }}
         run: |
           image_name="${STK_DOCKER_IMAGE}-python${MAIN_PYTHON_VERSION}"
-          docker_name="stk-python${MAIN_PYTHON_VERSION}"
           container_name="stk-python${MAIN_PYTHON_VERSION}-${RUNNER}"
           echo "image=${image_name}" >> "${GITHUB_OUTPUT}"
+          echo "container=${container_name}" >> "${GITHUB_OUTPUT}"
 
       - name: "Start the container from the desired image"
         env:

--- a/.github/workflows/ci_cd_release.yml
+++ b/.github/workflows/ci_cd_release.yml
@@ -137,6 +137,7 @@ jobs:
           tree doc/source/_static/wheelhouse
 
       - name: "Generate the name of the Docker image and the container"
+        id: docker
         env:
           RUNNER: ${{ runner.name }}
         run: |

--- a/.github/workflows/ci_cd_release.yml
+++ b/.github/workflows/ci_cd_release.yml
@@ -137,30 +137,31 @@ jobs:
           tree doc/source/_static/wheelhouse
 
       - name: "Generate the name of the Docker image and the container"
-        id: docker
+        env:
+          RUNNER: ${{ env.RUNNER_NAME }}
         run: |
           image_name="${STK_DOCKER_IMAGE}-python${MAIN_PYTHON_VERSION}"
+          docker_name="stk-python${MAIN_PYTHON_VERSION}"
+          container_name="stk-python${MAIN_PYTHON_VERSION}-${RUNNER}"
           echo "image=${image_name}" >> "${GITHUB_OUTPUT}"
 
       - name: "Start the container from the desired image"
-        id: container
         env:
           STK_IMAGE: ${{ steps.docker.outputs.image }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
         run: |
           docker run \
             --detach -it \
             --network="host" \
+            --name="${STK_CONTAINER}" \
             --env ANSYSLMD_LICENSE_FILE="${LICENSE_SERVER_PORT}@${LICENSE_SERVER}" \
             --volume ${PWD}:/home/stk/pystk \
             "${STK_IMAGE}"
 
-          container_name=$(docker ps --latest --format "{{.Names}}")
-          echo "name=${container_name}" >> "${GITHUB_OUTPUT}"
-
       - name: "Install system dependencies required for building examples"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --user root \
@@ -186,7 +187,7 @@ jobs:
 
       - name: "Install Tox"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -195,7 +196,7 @@ jobs:
 
       - name: "Build the full documentation"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -210,7 +211,7 @@ jobs:
 
       - name: "Stop the container"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         if: always()
         run: |
           docker stop "${STK_CONTAINER}"
@@ -240,29 +241,30 @@ jobs:
         id: docker
         env:
           PYTHON: python-${{ matrix.python }}
+          RUNNER: ${{ env.RUNNER_NAME }}
         run: |
           python_image_name="${STK_DOCKER_IMAGE}-${PYTHON}"
+          container_name="stk-python${PYTHON}-${RUNNER}"
           echo "image=${python_image_name}" >> "${GITHUB_OUTPUT}"
+          echo "container=${container_name}" >> "${GITHUB_OUTPUT}"
 
       - name: "Start the container from the desired image"
-        id: container
         env:
           STK_IMAGE: ${{ steps.docker.outputs.image }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
         run: |
           docker run \
             --detach -it \
             --network="host" \
+            --name="${STK_CONTAINER}" \
             --env ANSYSLMD_LICENSE_FILE="${LICENSE_SERVER_PORT}@${LICENSE_SERVER}" \
             --volume ${PWD}:/home/stk/pystk \
             "${STK_IMAGE}"
 
-          container_name=$(docker ps --latest --format "{{.Names}}")
-          echo "name=${container_name}" >> "${GITHUB_OUTPUT}"
-
       - name: "Install the project with the testing dependencies"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -271,7 +273,7 @@ jobs:
 
       - name: "Install coverage dependencies"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -282,7 +284,7 @@ jobs:
 
       - name: "Run the extensions tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -291,7 +293,7 @@ jobs:
 
       - name: "Run the API migration assistant tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -300,7 +302,7 @@ jobs:
 
       - name: "Run the aviator tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -309,7 +311,7 @@ jobs:
 
       - name: "Run the non graphics stk tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -318,7 +320,7 @@ jobs:
 
       - name: "Run the graphics only stk tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -327,7 +329,7 @@ jobs:
 
       - name: "Run the vgt tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -336,7 +338,7 @@ jobs:
 
       - name: "Run the doc snippet tests"
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -348,7 +350,7 @@ jobs:
       - name: "Combine all coverage results"
         if: ${{ matrix.python == env.MINIMUM_PYTHON_VERSION }}
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR}/.cov \
@@ -358,7 +360,7 @@ jobs:
       - name: "Generate coverage report in XML and HTML"
         if: ${{ matrix.python == env.MINIMUM_PYTHON_VERSION }}
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker exec \
             --workdir ${PYSTK_DIR} \
@@ -386,7 +388,7 @@ jobs:
       - name: "Stop the container"
         if: always()
         env:
-          STK_CONTAINER: ${{ steps.container.outputs.name }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
         run: |
           docker stop "${STK_CONTAINER}"
           docker logs "${STK_CONTAINER}"

--- a/doc/source/changelog/848.fixed.md
+++ b/doc/source/changelog/848.fixed.md
@@ -1,0 +1,1 @@
+Use runner name when starting a new container


### PR DESCRIPTION
This pull-request avoids relying on the random name imposed by Docker when starting a new container. Instead, containers created have in its name the name of the runner, ensuring no name conflicts or race conditions occur.