### PR TITLE
fix(ci): adjust container name in nightly build

### DIFF
--- a/.github/workflows/ci_cd_night.yml
+++ b/.github/workflows/ci_cd_night.yml
@@ -103,7 +103,7 @@ jobs:
       - name: "Start the container from the desired image"
         env:
           STK_IMAGE: ${{ steps.docker.outputs.image }}
-          STK_CONTAINER: ${{ steps.docker.outputs.image }}
+          STK_CONTAINER: ${{ steps.docker.outputs.container }}
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
         run: |
           docker run \

--- a/doc/source/changelog/851.fixed.md
+++ b/doc/source/changelog/851.fixed.md
@@ -1,0 +1,1 @@
+Adjust container name in nightly build


### PR DESCRIPTION
Addresses nightly build failure, see https://github.com/ansys/pystk/actions/runs/18236847476/job/51932338086#step:6:26