### PR TITLE
docs: remove PyPI installation tab for development versions

### DIFF
--- a/doc/source/changelog/870.documentation.md
+++ b/doc/source/changelog/870.documentation.md
@@ -1,0 +1,1 @@
+Remove PyPI installation tab for development versions

--- a/doc/source/getting-started/install/linux/local.rst
+++ b/doc/source/getting-started/install/linux/local.rst
@@ -58,12 +58,14 @@ Install Linux artifacts by using the `pip`_ command:
     .. tab-set::
         :sync-group: artifacts
 
+        {% if not PYSTK_VERSION.endswith('dev0') %}
         .. tab-item:: **PyPI install**
             :sync: pypi
 
             .. code-block:: text
 
                 python -m pip install "ansys-stk=={{ PYSTK_VERSION }}"
+        {% endif %}
 
         .. tab-item:: **Wheels install**
             :sync: wheels

--- a/doc/source/getting-started/install/windows/local.rst
+++ b/doc/source/getting-started/install/windows/local.rst
@@ -58,12 +58,14 @@ Install Windows artifacts by using the `pip`_ command:
     .. tab-set::
         :sync-group: artifacts
 
+        {% if not PYSTK_VERSION.endswith('.dev0') %}
         .. tab-item:: **PyPI install**
             :sync: pypi
 
             .. code-block:: text
 
                 python -m pip install "ansys-stk=={{ PYSTK_VERSION }}"
+        {% endif %}
 
         .. tab-item:: **Wheels install**
             :sync: wheels

--- a/tox.ini
+++ b/tox.ini
@@ -186,7 +186,7 @@ extras =
     extensions
     jupyter
 dependency_groups =
-    doc
+    links,html,pdf: doc
 commands =
     # Remove rendered documentation and additional static files
     clean: python -c "import shutil, sys; shutil.rmtree(sys.argv[1], ignore_errors=True)" "{toxinidir}/{env:BUILD_DIR}"


### PR DESCRIPTION
Fix #869 by removing PyPI installation guidelines only in development versions. The `PYSTK_VERSION` variable available in the global context for Jinja is used to conditionally include or not the tab for PyPI.

In addition, it also ensures that no dependencies or groups are installed in the `tox -e doc-serve` environment since this environment just calls the `python -m http.server`, which is included in the standard library.