### PR TITLE
docs: ignore linkcheck on repository changelog links

### DIFF
--- a/doc/source/changelog/1003.documentation.md
+++ b/doc/source/changelog/1003.documentation.md
@@ -1,0 +1,1 @@
+Ignore linkcheck on repository changelog links

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -182,6 +182,7 @@ autosectionlabel_maxdepth = 6
 
 # -- Linkcheck configuration -------------------------------------------------
 user_repo = f"{html_context['github_user']}/{html_context['github_repo']}"
+linkcheck_exclude_documents = ["changelog"]
 linkcheck_ignore = [
     r"https://www.ansys.com/*",
     # Requires sign-in


### PR DESCRIPTION
We shouldn't check the PR links on the changelog... this can get extremely busy and useless in the long run. All PRs should exist since they point to content inside the repository.