### PR TITLE
docs: ignore linkcheck on wheelhouses

### DIFF
--- a/doc/source/changelog/1004.documentation.md
+++ b/doc/source/changelog/1004.documentation.md
@@ -1,0 +1,1 @@
+Ignore linkcheck on wheelhouses

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -182,6 +182,7 @@ autosectionlabel_maxdepth = 6
 
 # -- Linkcheck configuration -------------------------------------------------
 user_repo = f"{html_context['github_user']}/{html_context['github_repo']}"
+linkcheck_exclude_documents = ["_static/artifacts/.*"] # Ignore links to wheelhouses for now
 linkcheck_ignore = [
     r"https://www.ansys.com/*",
     # Requires sign-in
@@ -198,7 +199,6 @@ linkcheck_ignore = [
     rf"https://{cname}/version/{release}/examples/.*\.pdf",
     rf"https://{cname}/version/{release}/examples/.*\.ipynb",
     rf"https://{cname}/version/{release}/examples/.*\.py",
-    rf"_static/artifacts/*", # Ignore links to wheelhouse for now
 ]
 
 # -- Declare the Jinja context -----------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -182,7 +182,7 @@ autosectionlabel_maxdepth = 6
 
 # -- Linkcheck configuration -------------------------------------------------
 user_repo = f"{html_context['github_user']}/{html_context['github_repo']}"
-linkcheck_exclude_documents = ["_static/artifacts/.*"] # Ignore links to wheelhouses for now
+linkcheck_exclude_documents = ["artifacts"] # Ignore links to wheelhouses for now
 linkcheck_ignore = [
     r"https://www.ansys.com/*",
     # Requires sign-in

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -198,6 +198,7 @@ linkcheck_ignore = [
     rf"https://{cname}/version/{release}/examples/.*\.pdf",
     rf"https://{cname}/version/{release}/examples/.*\.ipynb",
     rf"https://{cname}/version/{release}/examples/.*\.py",
+    rf"_static/artifacts/*", # Ignore links to wheelhouse for now
 ]
 
 # -- Declare the Jinja context -----------------------------------------------


### PR DESCRIPTION
Nightly and PR builds have been failing with errors such as the one below. This change skips those linkchecks for now so we can investigate starting from passing builds.

```
( artifacts: line    1) broken    _static/wheelhouse/ansys-stk-v0.4.dev0-all-wheelhouse-ubuntu-latest-3.10/ansys-stk-v0.4.dev0-all-wheelhouse-ubuntu-latest-3.10.zip -
```