### PR TITLE
docs: affection to affecting

### DIFF
--- a/doc/source/changelog/1057.documentation.md
+++ b/doc/source/changelog/1057.documentation.md
@@ -1,0 +1,1 @@
+Replace affection by affecting

--- a/doc/source/contribute/developer.rst
+++ b/doc/source/contribute/developer.rst
@@ -53,7 +53,7 @@ Fork the repository
 
 Forking the repository is the first step to contributing to the project. This
 allows you to have your own copy of the project so you can make changes without
-effecting the main project. Once you have made your changes, you can submit a
+affecting the main project. Once you have made your changes, you can submit a
 pull-request to the main project to have your changes reviewed and merged.
 
 .. button-link:: https://github.com/ansys/pystk/fork

--- a/doc/source/contribute/developer.rst
+++ b/doc/source/contribute/developer.rst
@@ -53,7 +53,7 @@ Fork the repository
 
 Forking the repository is the first step to contributing to the project. This
 allows you to have your own copy of the project so you can make changes without
-affection the main project. Once you have made your changes, you can submit a
+effecting the main project. Once you have made your changes, you can submit a
 pull-request to the main project to have your changes reviewed and merged.
 
 .. button-link:: https://github.com/ansys/pystk/fork


### PR DESCRIPTION
Within the "Contributing as a developer" page, under the "Fork the repository" subsection, I'm fixing the typo "affection" to affecting. 