### PR TITLE
docs: document the use of no_graphics

### DIFF
--- a/doc/source/changelog/1067.documentation.md
+++ b/doc/source/changelog/1067.documentation.md
@@ -1,0 +1,1 @@
+Document the use of no_graphics

--- a/doc/source/getting-started/install/linux/docker.rst
+++ b/doc/source/getting-started/install/linux/docker.rst
@@ -110,7 +110,7 @@ the Internet Protocol (IP) of the machine hosting the license server.
 Start a container
 =================
 
-With the artifacts and the license in place, start a Docker container and share
+With the artifacts and the license in place, start a Docker container, and share
 the working directory as a volume. This enables you to write scripts using the tools
 in the host machine while isolating their execution inside the container.
 

--- a/doc/source/getting-started/install/windows/docker.rst
+++ b/doc/source/getting-started/install/windows/docker.rst
@@ -114,7 +114,7 @@ the Internet Protocol (IP) of the machine hosting the license server.
 Start a container
 =================
 
-With the artifacts and the license in place, start a Docker container and share
+With the artifacts and the license in place, start a Docker container, and share
 the working directory as a volume. This enables you to write scripts using the tools
 in the host machine while isolating their execution inside the container.
 

--- a/doc/source/user-guide/api-structure.rst
+++ b/doc/source/user-guide/api-structure.rst
@@ -165,7 +165,7 @@ Strategy pattern
 This section provides information on the strategy pattern as it relates to
 PySTK. The strategy pattern enables you to delegate behavior to different
 strategies that can be selected at runtime. It is useful when you need to vary
-the behavior of certain components, such as authentication methods or request
+the behavior of certain components, such as authentication methods, or request
 handling strategies, without altering the objects that use them.
 
 gRPC call batching

--- a/doc/source/user-guide/code-snippets.rst
+++ b/doc/source/user-guide/code-snippets.rst
@@ -1355,7 +1355,7 @@ Compute an access between two STK objects (using object path)
 
 .. _ComputeAccess:
 
-Compute an access between two STK objects (using istkobject interface)
+Compute an access between two STK objects (using ISTKObject interface)
 ======================================================================
 
 .. code-block:: python

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -20,12 +20,14 @@ Hohmann
 IIF
 intervisibility
 IPython
+ISTKObject
 Keplerian
 LOD
 lod
 MCS
 MTO
 namespace
+namespaces
 Nemo
 [Nn]um[Pp]y
 Pandas
@@ -42,8 +44,10 @@ STK
 STK Desktop
 STKEngine
 STK Engine
+STKRuntime
 Subpackages
 Tkinter
 Tox
 triangulator
 waypoint
+waypoints

--- a/examples/create-load-scenarios.py
+++ b/examples/create-load-scenarios.py
@@ -15,7 +15,8 @@ stk = STKEngine.start_application(no_graphics=False)
 print(f"Using {stk.version}")
 # -
 
-# This creates an instance of the STK application. Setting `no_graphics` to `False` opens the STK window.
+# This creates an instance of STK Engine. Setting `no_graphics` to `False` enables graphics support, but it does not open an STK Desktop window.
+# For details on `no_graphics`, see the `STK programming help <https://help.agi.com/stkdevkit/index.htm#stkEngine/NoGraphics.htm>`_.
 
 # Next, it's time to create a scenario.
 


### PR DESCRIPTION
Fix #952 by updating the information about the `no_graphics` parameter in the `Create and load scenarios` example and linking to the official AGI Help Guide.