### PR TITLE
docs: re-enable linkcheck for links to examples

### DIFF
--- a/doc/source/changelog/1098.documentation.md
+++ b/doc/source/changelog/1098.documentation.md
@@ -1,0 +1,1 @@
+Re-enable linkcheck for links to examples

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -192,11 +192,6 @@ linkcheck_ignore = [
     # Spurious failures
     r"https://www.khronos.org/collada/",
     r"https://www.khronos.org/gltf/",
-    # Ignore links to the examples pdf/ipynb/py files as they are not
-    # available until documentation is not published
-    rf"https://{cname}/version/{release}/examples/.*\.pdf",
-    rf"https://{cname}/version/{release}/examples/.*\.ipynb",
-    rf"https://{cname}/version/{release}/examples/.*\.py",
 ]
 
 # -- Declare the Jinja context -----------------------------------------------
@@ -207,6 +202,17 @@ if not BUILD_API:
 BUILD_EXAMPLES = True if os.environ.get("BUILD_EXAMPLES", "true") == "true" else False
 if not BUILD_EXAMPLES:
     exclude_patterns.extend(["examples/**"])
+    linkcheck_ignore.extend(
+        [
+            # Ignore links to the examples pdf/ipynb/py files as they are not
+            # available until documentation is published
+            rf"https://{cname}/version/{release}/examples/.*\.pdf",
+            rf"https://{cname}/version/{release}/examples/.*\.ipynb",
+            rf"https://{cname}/version/{release}/examples/.*\.py",
+            r"https://github\.com/ansys/pystk/blob/main/examples/create-load-scenarios\.py",
+            r"https://github\.com/ansys/pystk/blob/main/examples/results-graphs\.py",
+        ]
+    )
 else:
     extensions.extend(["myst_parser", "nbsphinx"])
     nbsphinx_execute = "always"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -192,9 +192,6 @@ linkcheck_ignore = [
     # Spurious failures
     r"https://www.khronos.org/collada/",
     r"https://www.khronos.org/gltf/",
-    # TODO: Determine a way to link to examples without breaking the linkcheck
-    # https://github.com/ansys/pystk/issues/657
-    r"../examples/",
     # Ignore links to the examples pdf/ipynb/py files as they are not
     # available until documentation is not published
     rf"https://{cname}/version/{release}/examples/.*\.pdf",

--- a/doc/source/links.rst
+++ b/doc/source/links.rst
@@ -7,6 +7,8 @@
 .. _PySTK labels: https://github.com/ansys/pystk/labels
 .. _docker/ directory: https://github.com/ansys/pystk/tree/docker/
 .. _code snippet directory: https://github.com/ansys/pystk/tree/main/tests/doc_snippets_tests
+.. _create and load scenarios example: https://github.com/ansys/pystk/blob/main/examples/create-load-scenarios.py
+.. _results and graphs example: https://github.com/ansys/pystk/blob/main/examples/results-graphs.py
 
 .. Ansys products
 

--- a/doc/source/user-guide/create-load-scenarios.rst
+++ b/doc/source/user-guide/create-load-scenarios.rst
@@ -22,4 +22,4 @@ You can create an unlimited number of scenarios with STK; however, only one scen
 STK scenarios in PySTK
 ======================
 
-To learn more about using PySTK to automate the process of creating, saving, and loading scenarios, see `this example <../examples/create-load-scenarios>`_.
+To learn more about using PySTK to automate the process of creating, saving, and loading scenarios, see the `create and load scenarios example`_.

--- a/doc/source/user-guide/results-graphs.rst
+++ b/doc/source/user-guide/results-graphs.rst
@@ -44,4 +44,4 @@ In the `Data Providers` section of the `Report Style` window, the data providers
 
 Groups, data providers, and elements are the organizing principles of the data provider capability provided by the STK object model.
 
-To learn more about data providers, their results, and STK graphs and reports, explore `this example <../examples/results-graphs>`_.
+To learn more about data providers, their results, and STK graphs and reports, explore the `results and graphs example`_.


### PR DESCRIPTION
Summary:
- replace two user guide example links that pointed to transient doc build paths with stable GitHub example file links
- add the new example link targets to doc/source/links.rst
- remove the ../examples/ ignore pattern from linkcheck_ignore in doc/source/conf.py

Validation:
- BUILD_EXAMPLES=false uvx --from tox tox -c tox.ini -e doc-links
  - confirmed the updated example links are checked as ok by linkcheck
  - command still fails in this environment due unrelated external SSL certificate errors
